### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/Text/Table/List.pm6
+++ b/lib/Text/Table/List.pm6
@@ -1,4 +1,4 @@
-class Text::Table::List;
+unit class Text::Table::List;
 
 has @!lines;
 has $!text;

--- a/lib/Text/Table/List/ASCII.pm6
+++ b/lib/Text/Table/List/ASCII.pm6
@@ -1,6 +1,6 @@
 use Text::Table::List;
 
-class Text::Table::List::ASCII is Text::Table::List;
+unit class Text::Table::List::ASCII is Text::Table::List;
 
 ### Default drawing characters.
 has $.top-left     = "#";


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class`, `role` or `grammar` declarations (unless it uses a
block).  Code still using the old blockless semicolon form will throw a
warning. This commit stops the warning from appearing in the new Rakudo.
