### PR TITLE
Remove now superfluous braces from hash declaration

### DIFF
--- a/t/simple.t
+++ b/t/simple.t
@@ -38,12 +38,11 @@ my $t2 = Text::Table::List.new(:length(40)).start;
 
 $t2.label("Small test");
 $t2.line;
-my %staff = {
+my %staff =
   "Susan Smith"    => "CEO",
   "Kevin Michaels" => "COO",
   "Richard Frank"  => "Janitor",
-  "Lisa Dawkins"   => "Designer",
-};
+  "Lisa Dawkins"   => "Designer";
 $t2.field(|%staff);
 
 $wanted = "╔══════════════════════════════════════╗


### PR DESCRIPTION
Hashes no longer need to be declared with braces (as is needed in Perl 5).
The old form is deprecated and will be removed in Rakudo version 2015.07.
This change converts the code to the Perl 6 hash declaration syntax.
