### PR TITLE
Replace hash input to field() with list of Pairs

### DIFF
--- a/lib/Text/Table/List.pm6
+++ b/lib/Text/Table/List.pm6
@@ -82,8 +82,9 @@ multi method field ($name, $value) {
   @!lines.push: $line;
 }
 
-multi method field (*%fields) {
-  for %fields.kv -> $name, $value {
+multi method field (*@fields) {
+  for @fields -> $field {
+    my ($name, $value) = $field.kv;
     self.field($name, $value);
   }
 }

--- a/t/ascii.t
+++ b/t/ascii.t
@@ -38,13 +38,12 @@ my $t2 = Text::Table::List::ASCII.new(:length(40)).start;
 
 $t2.label("Small test");
 $t2.line;
-my %staff = {
+my @staff =
   "Susan Smith"    => "CEO",
   "Kevin Michaels" => "COO",
   "Richard Frank"  => "Janitor",
-  "Lisa Dawkins"   => "Designer",
-};
-$t2.field(|%staff);
+  "Lisa Dawkins"   => "Designer";
+$t2.field(|@staff);
 
 $wanted = "#======================================#
 | Small test                           |

--- a/t/simple.t
+++ b/t/simple.t
@@ -38,13 +38,12 @@ my $t2 = Text::Table::List.new(:length(40)).start;
 
 $t2.label("Small test");
 $t2.line;
-my %staff = {
+my @staff =
   "Susan Smith"    => "CEO",
   "Kevin Michaels" => "COO",
   "Richard Frank"  => "Janitor",
-  "Lisa Dawkins"   => "Designer",
-};
-$t2.field(|%staff);
+  "Lisa Dawkins"   => "Designer";
+$t2.field(|@staff);
 
 $wanted = "╔══════════════════════════════════════╗
 ║ Small test                           ║


### PR DESCRIPTION
This is because a hash does not guarantee a given order.  The reason the
simple.t and ascii.t tests worked previously is due to a quirk of MoarVM
where the input ordering was preserved on hashes.  This has since been
corrected, and hashes now behave as unordered collections similarly to other
languages (e.g. Perl 5).  In order to retain the functionality that the
field() method accepts a list of key-value pairs and generates a table with
a given order from this input data, it seemed that explicitly using a list
of Pairs to be a sensible option, which is what is implemented here.

This is provided in the hope that it behaves in the way that the author wishes and in the hope that it helps!  Comments and feedback are most certainly welcome.
